### PR TITLE
Setup myid even if match host with its ip address setup

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,6 +2,7 @@
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time={{apt_cache_timeout}}
   tags: bootstrap
+  when: update_apt_cache is defined
 
 - name: Apt install required system packages.
   apt: pkg={{item}} state=installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,5 @@
   when: no_upstart is defined
 
 - include: common-config.yml
+
+- meta: flush_handlers

--- a/templates/myid.j2
+++ b/templates/myid.j2
@@ -2,9 +2,13 @@
 {% if server.host is defined %}
 {% if server.host == inventory_hostname %}
 {{ server.id }}
+{% elif server.host in ansible_all_ipv4_addresses %}
+{{ server.id }}
+{% elif server.ip is defined and server.ip in ansible_all_ipv4_addresses %}
+{{ server.id }}
 {% endif %}
 {% else %}
-{% if server == inventory_hostname %}
+{% if server == inventory_hostname or server in ansible_all_ipv4_addresses %}
 {{ loop.index }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
* Added logic to check if host provided is an ip address setup on that
host for setting myid.
* Run apt-get update only when specified
* flush handlers so that zookeeper applied configurations changed and
  service restarted within the role itself, so that any client
configurations after this role execution has zookeeper available with
latest configurations